### PR TITLE
Remove constructor bodies in ibor and overnight indexes

### DIFF
--- a/QuantExt-SWIG/SWIG/qle_indexes.i
+++ b/QuantExt-SWIG/SWIG/qle_indexes.i
@@ -268,9 +268,7 @@ class Name : public IborIndex {
   public:
     Name(const Period& tenor,
          const Handle<YieldTermStructure>& h =
-                                Handle<YieldTermStructure>()) {
-        return new Name(new Name(tenor,h));
-    }
+                                Handle<YieldTermStructure>());
 };
 %enddef
 
@@ -282,9 +280,7 @@ using QuantExt::Name;
 class Name : public OvernightIndex {
   public:
     Name(const Handle<YieldTermStructure>& h =
-                                Handle<YieldTermStructure>()) {
-        return new Name(new Name(h));
-    }
+                                Handle<YieldTermStructure>());
 };
 %enddef
 


### PR DESCRIPTION
This looks like a confusion with %extend syntax for constructors[1]. These are regular constructors, so the syntax is wrong, but the bodies are ignored by SWIG anyway.

[1] https://www.swig.org/Doc4.1/Python.html#Python_nn43