### PR TITLE
Remove LargeJointCalendar from interface

### DIFF
--- a/Docs/ore-swig.tex
+++ b/Docs/ore-swig.tex
@@ -240,7 +240,6 @@ The current hacky fix for that would be to comment out the function in OREData/u
                 \subitem Spain
                 \subitem Switzerland
                 \subitem Wmr
-                \subitem LargeJointCalendar
         \item \textbf{qle\_currencies.i}
                 \subitem TNDCurrency
                 \subitem EGPCurrency

--- a/QuantExt-SWIG/SWIG/qle_calendars.i
+++ b/QuantExt-SWIG/SWIG/qle_calendars.i
@@ -38,7 +38,6 @@ using QuantExt::Philippines;
 using QuantExt::RussiaModified;
 using QuantExt::Spain;
 using QuantExt::Wmr;
-using QuantExt::LargeJointCalendar;
 %}
 
 class Belgium : public Calendar {
@@ -199,23 +198,4 @@ class Wmr : public Calendar {
     Wmr(Market market = Settlement);
 };
 
-class LargeJointCalendar : public Calendar {
-    LargeJointCalendar(const std::vector<QuantLib::Calendar>&,
-                                QuantLib::JointCalendarRule = QuantLib::JoinHolidays);
-};
-
 #endif
-
-
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
Hi,
QuantLib's `JointCalendar` provides the same vector-based constructor since QL-SWIG version [1.31](https://github.com/lballabio/QuantLib-SWIG/pull/558) meaning this is now somewhat superfluous. As mentioned in #26, the class removal should be rather harmless as its current interface is broken in SWIG. 

I have an old branch somewhere with proper deprecation/deletion within QuantExt as well.