### PR TITLE
add setScriptLibrary to ORE-SWIG

### DIFF
--- a/OREAnalytics-SWIG/SWIG/orea_app.i
+++ b/OREAnalytics-SWIG/SWIG/orea_app.i
@@ -90,6 +90,8 @@ public:
     void setCurveConfigsFromFile(const std::string& fileName);
     void setPricingEngine(const std::string& xml);
     void setPricingEngineFromFile(const std::string& fileName);
+    void setScriptLibrary(const std::string& xml);
+    void setScriptLibraryFromFile(const std::string& fileName);
     void setTodaysMarketParams(const std::string& xml);
     void setTodaysMarketParamsFromFile(const std::string& fileName);
     void setPortfolio(const std::string& xml); 


### PR DESCRIPTION
If I could make a wish for the next ORE-SWIG python package, it's adding these two commands, as we have quite a lot of scripted trades.

-regards
Roland